### PR TITLE
can_fly_with_deku_leaf_outdoors() logic fixes

### DIFF
--- a/locations/locations.json
+++ b/locations/locations.json
@@ -2261,8 +2261,8 @@
                         "chest_unopened_img": "images/items/chest_metal.png",
                         "chest_opened_img": "images/items/chest_metal_gray.png",
                         "access_rules": ["hookshot,sword","hookshot,boomerang","hookshot,bow",
-                        "hookshot,bombs","hookshot,hammer","$can_fly,bow","$can_fly,boomerang,sword",
-                        "$can_fly,boomerang,bombs","$can_fly,boomerang,hammer"],
+                        "hookshot,bombs","hookshot,hammer","$can_fly,$can_change_wind,bow","$can_fly,$can_change_wind,boomerang,sword",
+                        "$can_fly,$can_change_wind,boomerang,bombs","$can_fly,$can_change_wind,boomerang,hammer"],
                         "visibility_rules": ["puzzlecaves_on","combat_on"]
                     }
                 ],

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -879,7 +879,7 @@
 		            {
                         "name": "Bird-Man Contest - First Prize",
                         "item_count": 1,
-                        "access_rules": ["leaf,magic_2"],
+                        "access_rules": ["leaf,magic_2,$can_change_wind"],
                         "visibility_rules": ["minigames_on"]
                     },
                     {

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -460,7 +460,7 @@
                         "item_count": 1,
                         "chest_unopened_img": "images/items/chest_metal.png",
                         "chest_opened_img": "images/items/chest_metal_gray.png",
-                        "access_rules": ["$can_change_wind,$can_magicarrow,$can_fly","$can_magicarrow,hookshot"],
+                        "access_rules": ["$can_change_wind,$can_magicarrow,$can_fly","$can_change_wind,$can_magicarrow,hookshot"],
                         "visibility_rules": ["shortsq_on"]
                     },
 		            {

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -1884,7 +1884,7 @@
                         "item_count": 1,
                         "chest_unopened_img": "images/items/chest_metal.png",
                         "chest_opened_img": "images/items/chest_metal_gray.png",
-                        "access_rules": ["leaf,hookshot","$can_fly"],
+                        "access_rules": ["leaf,hookshot","$can_fly,$can_change_wind"],
                         "visibility_rules": ["islandpuzzles_on"]
                     },
                     {

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -1437,7 +1437,7 @@
                         "item_count": 1,
                         "chest_unopened_img": "images/items/chest_spiky.png",
                         "chest_opened_img": "images/items/chest_spiky_gray.png",
-                        "access_rules": ["hookshot","$can_fly"],
+                        "access_rules": ["hookshot","$can_fly,$can_change_wind"],
                         "visibility_rules": ["islandpuzzles_on"]
                     },
                     {

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -1703,7 +1703,7 @@
                         "item_count": 1,
                         "chest_unopened_img": "images/items/chest_metal.png",
                         "chest_opened_img": "images/items/chest_metal_gray.png",
-                        "access_rules": ["$can_fly,$can_change_wind"],
+                        "access_rules": ["$can_fly,$can_change_wind,$can_cut_grass","$can_fly,$can_change_wind,magic_2"],
                         "visibility_rules": ["islandpuzzles_on"]
                     }
                 ],


### PR DESCRIPTION
I noticed there were a few locations that use `can_fly_with_deku_leaf_outdoors()` (Deku Leaf + Magic + Wind Waker + Wind's Requiem) in the ap world's logic, but where the tracker was missing the Wind Waker + Wind's Requiem requirements.

Quite a few of these locations look to be quite easy to clear out-of-logic by having the swift sail to change the wind direction, so the Wind Waker + Wind's Requiem requirements could be marked as optional. I don't know Wind Waker well enough to be able to tell without trying these locations out though.

While checking the logic of the locations that use `can_fly_with_deku_leaf_outdoors()`, I noticed that `Forest Haven - Small Island Chest` was missing `can_cut_grass` or `magic_2` logic, so I have add a commit that fixes that too.

Each commit has a permalink to the current ap world logic for the location being fixed.